### PR TITLE
fix: fixed heroku deployment

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -31,9 +31,10 @@ jobs:
         uses: canastro/copy-action@0.0.2
         with:          
           source: ./Todo.Backend/.heroku/Dockerfile
-          target: ./Todo.Backend/Dockerfile          
+          target: ./Todo.Backend/Dockerfile
+          
       - name: Build, Push and Deploy to Heroku
-        uses: jctaveras/heroku-deploy@v2.1.3
+        uses: jctaveras/heroku-deploy@v2.1.3        
         with:
           email: ${{ secrets.HEROKU_EMAIL }}
           api_key: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -31,7 +31,7 @@ jobs:
         uses: canastro/copy-action@0.0.2
         with:          
           source: ./Todo.Backend/.heroku/Dockerfile
-          target: ./Todo.Backend/Dockerfile
+          target: ./Dockerfile
           
       - name: Build, Push and Deploy to Heroku
         uses: jctaveras/heroku-deploy@v2.1.3        
@@ -39,6 +39,6 @@ jobs:
           email: ${{ secrets.HEROKU_EMAIL }}
           api_key: ${{ secrets.HEROKU_API_KEY }}
           app_name: ${{ secrets.HEROKU_APP_NAME }}
-          dockerfile_path: './Todo.Backend'
+          dockerfile_path: './'
           formation: 'web'
 

--- a/Todo.Backend/.heroku/Dockerfile
+++ b/Todo.Backend/.heroku/Dockerfile
@@ -1,8 +1,9 @@
 # ----------------------------------------------------------------------------------------------------
-# This Dockerfile is copied to ../Todo.Backend during deployment and replaces the original Dockerfile.
+# This Dockerfile is copied to the project root during deployment.
 #
-# This is done due to current limitations of the used heroku deploy github action where the build 
-# context path and the docker file path must be the same.
+# This is done due to current limitations of the used heroku deploy github action which does not
+# work correctly when you don't build from the root directory (e. g. due to heroku cli pushing based
+# on the Dockerfile and the action does not provide the path context when invoking cli commands)
 # ----------------------------------------------------------------------------------------------------
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
@@ -10,9 +11,9 @@ WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
-COPY ["Todo.Backend.csproj", "./"]
+COPY ["./Todo.Backend/Todo.Backend.csproj", "./"]
 RUN dotnet restore "Todo.Backend.csproj"
-COPY . .
+COPY ./Todo.Backend/ .
 WORKDIR "/src/."
 RUN dotnet build "Todo.Backend.csproj" -c Release -o /app/build
 

--- a/Todo.Backend/.heroku/Dockerfile
+++ b/Todo.Backend/.heroku/Dockerfile
@@ -1,16 +1,23 @@
+# ----------------------------------------------------------------------------------------------------
+# This Dockerfile is copied to ../Todo.Backend during deployment and replaces the original Dockerfile.
+#
+# This is done due to current limitations of the used heroku deploy github action where the build 
+# context path and the docker file path must be the same.
+# ----------------------------------------------------------------------------------------------------
+
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
-COPY ["backend.csproj", "./"]
-RUN dotnet restore "backend.csproj"
+COPY ["Todo.Backend.csproj", "./"]
+RUN dotnet restore "Todo.Backend.csproj"
 COPY . .
 WORKDIR "/src/."
-RUN dotnet build "backend.csproj" -c Release -o /app/build
+RUN dotnet build "Todo.Backend.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "backend.csproj" -c Release -o /app/publish
+RUN dotnet publish "Todo.Backend.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
The issue was that sub directories don't work correctly with the 3rd party heroku deploy action since the heroku cli for push and release is invoked from the root directory so the Dockerfile needs to be in the root directory, too. I adapted the Dockerfile for heroku so it can be copied to the root directory of the project.