### PR TITLE
build: changed triggers for workflows

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -4,10 +4,8 @@ name: Deploy to Heroku
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  workflow_run:
-    workflows: ["Run Unit Tests"]
-    types: [completed]
+  push:
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -16,9 +14,7 @@ on:
 jobs:
   deploy:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    # Only run after the unit tests completed and only if this is a push
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest    
     # && github.event.workflow_run.event == 'push' && github.ref == 'refs/head/main' }}
     environment: todo-app-heroku
 
@@ -27,6 +23,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v2
+        
+      - name: Run Unit Test
+        run: dotnet test --verbosity normal
         
       - name: Copy heroku Dockerfile
         # You may pin to the exact commit or the version.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,6 @@
 name: Run Unit Tests
 
-on:
-  push:
-    branches: [ main ]
+on:  
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
The heroku and unit test workflows are separated again since there was no (well documented?) way allowing me to run one workflow when creating a PR and on push and another based on that workflow only on push and only when it was successful